### PR TITLE
Update URL for JSON benchmark input

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ v8 --runtime-call-stats out/json.js | grep Parse
 
 The source files in this repository are released under the Apache 2.0 license, as detailed in the LICENSE file.
 
-The scripts in this repository dynamically download [`JetStream2/SeaMonster/inspector-json-payload.js`](https://raw.githubusercontent.com/WebKit/webkit/ffdd2799d3237993354978b9d0cdd1d248fe3787/PerformanceTests/JetStream2/SeaMonster/inspector-json-payload.js), which has its own license:
+The scripts in this repository dynamically download [`JetStream2/SeaMonster/inspector-json-payload.js`](https://raw.githubusercontent.com/WebKit/WebKit/ab7171c1d63acb8c77216b5a11f98323b56b998b/PerformanceTests/JetStream2/SeaMonster/inspector-json-payload.js), which has its own license:
 
 ```
 /*

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "fetch-payload": "curl -s https://raw.githubusercontent.com/WebKit/WebKit/main/PerformanceTests/JetStream2/SeaMonster/inspector-json-payload.js | sed 's/let obj/module.exports/' > data.js",
+    "fetch-payload": "curl -s https://raw.githubusercontent.com/WebKit/WebKit/ab7171c1d63acb8c77216b5a11f98323b56b998b/PerformanceTests/JetStream2/SeaMonster/inspector-json-payload.js | sed 's/let obj/module.exports/' > data.js",
     "install-js-engines": "jsvu && jsvu v8@7.8 && jsvu v8@7.7 && jsvu v8@7.6 && jsvu v8@7.5",
     "build": "mkdir -p out && node build.js",
     "postinstall": "npm run fetch-payload && npm run install-js-engines && npm run build",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "fetch-payload": "curl -s https://raw.githubusercontent.com/WebKit/webkit/ffdd2799d3237993354978b9d0cdd1d248fe3787/PerformanceTests/JetStream2/SeaMonster/inspector-json-payload.js | sed 's/let obj/module.exports/' > data.js",
+    "fetch-payload": "curl -s https://raw.githubusercontent.com/WebKit/WebKit/main/PerformanceTests/JetStream2/SeaMonster/inspector-json-payload.js | sed 's/let obj/module.exports/' > data.js",
     "install-js-engines": "jsvu && jsvu v8@7.8 && jsvu v8@7.7 && jsvu v8@7.6 && jsvu v8@7.5",
     "build": "mkdir -p out && node build.js",
     "postinstall": "npm run fetch-payload && npm run install-js-engines && npm run build",


### PR DESCRIPTION
It seems the link to `inspector-json-payload.js` is dead, so I've updated it. However, if you prefer I can pin this to an exact commit hash if you think that will make this more stable :)